### PR TITLE
feat: remove workflow-level inputs field from V2 schema

### DIFF
--- a/workflow_compiler/schema/README.md
+++ b/workflow_compiler/schema/README.md
@@ -1,0 +1,197 @@
+# Workflow Schema V2
+
+This directory contains the V2 workflow schema definition, examples, and validator.
+
+## Files
+
+### `v2_schema.json`
+Formal JSON Schema (Draft-07) defining the complete V2 workflow structure with:
+- Top-level: `name`, `description`, `tags`, `spec`, `metadata`
+- Spec structure: `triggers`, `nodes`, `edges`, `output`, `ui`
+- Node types: `task`, `tool`, `llm`, `if`, `for_each`
+- Validation rules for all fields
+
+### `validate_v2.py`
+Python validator that checks:
+- ✅ JSON Schema compliance (structure validation)
+- ✅ DAG properties (no cycles, all nodes connected, no orphans)
+- ✅ Node references (edges point to existing nodes)
+- ✅ Template expressions (balanced `${}` braces)
+
+Usage:
+```python
+from workflow_compiler.schema.validate_v2 import validate_workflow_v2
+import json
+
+with open('workflow.json') as f:
+    workflow = json.load(f)
+with open('workflow_compiler/schema/v2_schema.json') as f:
+    schema = json.load(f)
+
+is_valid, errors = validate_workflow_v2(workflow, schema)
+if not is_valid:
+    for error in errors:
+        print(error)
+```
+
+## Examples (`examples/v2/`)
+
+Seven diverse example workflows demonstrating V2 schema features:
+
+1. **`01_simple_email_alert.json`** - Sequential workflow
+   - Form submission → Format email → Send via Gmail
+   - Demonstrates: Basic flow, template expressions, `${trigger.config.*}` refs
+
+2. **`02_parallel_data_fetch.json`** - Parallel execution
+   - Fetch user & products simultaneously → Generate AI recommendation
+   - Demonstrates: Parallel edges (2 nodes from `_start`), LLM node with JSON output
+
+3. **`03_conditional_branching.json`** - Conditional logic
+   - Check email attachments → Upload to Drive OR log message
+   - Demonstrates: `if` node with `then`/`else` branches
+
+4. **`04_loop_processing.json`** - Iteration
+   - Fetch new signups → Send welcome email to each → Update database
+   - Demonstrates: `for_each` node, loop variable access (`${signup.email}`)
+
+5. **`05_complex_multi_step.json`** - Combined patterns
+   - Parallel fetch (sales + inventory) → LLM analysis → Conditional alert → Sheets → Email batch
+   - Demonstrates: All patterns combined, complex DAG
+
+6. **`06_database_crud.json`** - Database operations
+   - Webhook trigger → Extract changes → Audit log → Conditional email verification
+   - Demonstrates: Supabase CRUD, webhook triggers, audit patterns
+
+7. **`07_file_processing_pipeline.json`** - File processing
+   - Drive file upload → Download → LLM extraction → Save to DB → Notify
+   - Demonstrates: Sequential pipeline, file operations, AI processing
+
+## Key Schema Features
+
+### Explicit Execution Edges
+Workflows define explicit edges for DAG execution:
+```json
+"edges": [
+  {"from": "_start", "to": "node1"},
+  {"from": "_start", "to": "node2"},  // Parallel
+  {"from": "node1", "to": "node3"},
+  {"from": "node2", "to": "node3"},   // Join
+  {"from": "node3", "to": "_end"}
+]
+```
+
+### Template References
+Use `${...}` to reference:
+- Trigger data: `${trigger.data.email}`
+- **Trigger config**: `${trigger.config.integration_resource_id}`
+- Node outputs: `${user_data}`
+- Loop variables: `${signup.name}`
+
+**Note**: Inputs and outputs are defined at the **node level only** through `in` and `out` fields. There is no workflow-level `inputs` field.
+
+### Node Types
+
+**Task Node** - Set values
+```json
+{
+  "id": "format_text",
+  "type": "task",
+  "kind": "set",
+  "value": "Hello ${user.name}",
+  "out": "greeting"
+}
+```
+
+**Tool Node** - Execute tools
+```json
+{
+  "id": "send_email",
+  "type": "tool",
+  "tool": "gmail_send_email",
+  "in": {
+    "integration_resource_id": "${trigger.config.gmail_id}",
+    "to": ["${user.email}"],
+    "body_text": "${greeting}"
+  },
+  "out": "result"
+}
+```
+
+**LLM Node** - AI processing
+```json
+{
+  "id": "analyze",
+  "type": "llm",
+  "model": "gpt-4o-mini",
+  "prompt": "Analyze: ${data}",
+  "out": "insights",
+  "output": {
+    "mode": "json",
+    "schema": {
+      "schema": {
+        "type": "object",
+        "properties": {
+          "summary": {"type": "string"}
+        }
+      }
+    }
+  }
+}
+```
+
+**If Node** - Conditional branching
+```json
+{
+  "id": "check_status",
+  "type": "if",
+  "condition": "${status == 'active'}",
+  "then": [/* nodes */],
+  "else": [/* nodes */],
+  "out": "result"
+}
+```
+
+**For Each Node** - Iteration
+```json
+{
+  "id": "process_items",
+  "type": "for_each",
+  "items": "${users}",
+  "item_var": "user",
+  "body": [/* nodes */],
+  "out": "results"
+}
+```
+
+## Testing
+
+Run all validator tests:
+```bash
+uv run pytest workflow_compiler/tests/test_validate_v2.py -v
+```
+
+Validate all examples:
+```bash
+for file in workflow_compiler/schema/examples/v2/*.json; do
+  uv run python -c "
+from workflow_compiler.schema.validate_v2 import validate_workflow_v2
+import json
+
+with open('$file') as f:
+    workflow = json.load(f)
+with open('workflow_compiler/schema/v2_schema.json') as f:
+    schema = json.load(f)
+
+is_valid, errors = validate_workflow_v2(workflow, schema)
+print('✓ Valid' if is_valid else f'✗ Invalid: {errors}')
+"
+done
+```
+
+## Next Steps
+
+After schema stabilization:
+1. Update Pydantic models (`models.py`) to match V2 schema
+2. Migrate existing workflows in database
+3. Update compiler to read `spec.edges` for execution
+4. Update workflow agent to generate V2 schemas

--- a/workflow_compiler/schema/examples/v2/01_simple_email_alert.json
+++ b/workflow_compiler/schema/examples/v2/01_simple_email_alert.json
@@ -1,0 +1,42 @@
+{
+  "name": "Form Submission Alert",
+  "description": "Send email notification when contact form is submitted",
+  "tags": ["form", "email", "notification"],
+  "spec": {
+    "triggers": [{
+      "key": "form.hosted",
+      "config": {
+        "form_id": "contact_form",
+        "gmail_integration_id": 101
+      }
+    }],
+    "inputs": {},
+    "nodes": [
+      {
+        "id": "format_body",
+        "type": "task",
+        "kind": "set",
+        "value": "New submission:\nName: ${trigger.data.name}\nEmail: ${trigger.data.email}",
+        "out": "email_body"
+      },
+      {
+        "id": "send_email",
+        "type": "tool",
+        "tool": "gmail_send_email",
+        "in": {
+          "integration_resource_id": "${trigger.config.gmail_integration_id}",
+          "to": ["admin@company.com"],
+          "subject": "New Contact Form",
+          "body_text": "${email_body}"
+        },
+        "out": "result"
+      }
+    ],
+    "edges": [
+      {"from": "_start", "to": "format_body"},
+      {"from": "format_body", "to": "send_email"},
+      {"from": "send_email", "to": "_end"}
+    ],
+    "output": "${result}"
+  }
+}

--- a/workflow_compiler/schema/examples/v2/02_parallel_data_fetch.json
+++ b/workflow_compiler/schema/examples/v2/02_parallel_data_fetch.json
@@ -1,0 +1,69 @@
+{
+  "name": "Parallel Product Recommendation",
+  "description": "Fetch user and products in parallel, generate AI recommendation",
+  "tags": ["parallel", "ai", "supabase"],
+  "spec": {
+    "triggers": [{
+      "key": "schedule.cron",
+      "config": {
+        "cron": "0 9 * * *",
+        "timezone": "America/Los_Angeles",
+        "supabase_integration_id": 100
+      }
+    }],
+    "inputs": {},
+    "nodes": [
+      {
+        "id": "fetch_user",
+        "type": "tool",
+        "tool": "supabase_table_query",
+        "in": {
+          "integration_resource_id": "${trigger.config.supabase_integration_id}",
+          "table": "users",
+          "filters": {"id": {"eq": "user_123"}}
+        },
+        "out": "user"
+      },
+      {
+        "id": "fetch_products",
+        "type": "tool",
+        "tool": "supabase_table_query",
+        "in": {
+          "integration_resource_id": "${trigger.config.supabase_integration_id}",
+          "table": "products",
+          "filters": {"active": {"eq": true}}
+        },
+        "out": "products"
+      },
+      {
+        "id": "generate_recommendation",
+        "type": "llm",
+        "model": "gpt-4o-mini",
+        "prompt": "Given this user: ${user} and products: ${products}, recommend 3 products.",
+        "out": "recommendation",
+        "output": {
+          "mode": "json",
+          "schema": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "recommendations": {
+                  "type": "array",
+                  "items": {"type": "object"}
+                }
+              }
+            }
+          }
+        }
+      }
+    ],
+    "edges": [
+      {"from": "_start", "to": "fetch_user"},
+      {"from": "_start", "to": "fetch_products"},
+      {"from": "fetch_user", "to": "generate_recommendation"},
+      {"from": "fetch_products", "to": "generate_recommendation"},
+      {"from": "generate_recommendation", "to": "_end"}
+    ],
+    "output": "${recommendation}"
+  }
+}

--- a/workflow_compiler/schema/examples/v2/03_conditional_branching.json
+++ b/workflow_compiler/schema/examples/v2/03_conditional_branching.json
@@ -1,0 +1,53 @@
+{
+  "name": "Email Attachment Processor",
+  "description": "Save email attachments to Google Drive or log if none",
+  "tags": ["gmail", "gdrive", "conditional"],
+  "spec": {
+    "triggers": [{
+      "key": "poll.gmail.email_received",
+      "config": {
+        "integration_resource_id": 102,
+        "gdrive_integration_id": 201,
+        "query": "has:attachment",
+        "max_results": 5
+      }
+    }],
+    "inputs": {},
+    "nodes": [
+      {
+        "id": "check_attachments",
+        "type": "if",
+        "condition": "${trigger.data.attachments}",
+        "then": [
+          {
+            "id": "upload_to_drive",
+            "type": "tool",
+            "tool": "gdrive_upload_file",
+            "in": {
+              "integration_resource_id": "${trigger.config.gdrive_integration_id}",
+              "name": "${trigger.data.attachments[0].filename}",
+              "mime_type": "${trigger.data.attachments[0].mime_type}",
+              "folder_id": "1a2b3c4d5e"
+            },
+            "out": "drive_result"
+          }
+        ],
+        "else": [
+          {
+            "id": "log_no_attachments",
+            "type": "task",
+            "kind": "set",
+            "value": {"message": "No attachments found", "email_id": "${trigger.data.message_id}"},
+            "out": "log_result"
+          }
+        ],
+        "out": "result"
+      }
+    ],
+    "edges": [
+      {"from": "_start", "to": "check_attachments"},
+      {"from": "check_attachments", "to": "_end"}
+    ],
+    "output": "${result}"
+  }
+}

--- a/workflow_compiler/schema/examples/v2/04_loop_processing.json
+++ b/workflow_compiler/schema/examples/v2/04_loop_processing.json
@@ -1,0 +1,68 @@
+{
+  "name": "Bulk Welcome Emails",
+  "description": "Send welcome email to each new signup in batch",
+  "tags": ["loop", "email", "supabase"],
+  "spec": {
+    "triggers": [{
+      "key": "schedule.cron",
+      "config": {
+        "cron": "0 */4 * * *",
+        "supabase_integration_id": 103,
+        "gmail_integration_id": 104
+      }
+    }],
+    "inputs": {},
+    "nodes": [
+      {
+        "id": "fetch_new_signups",
+        "type": "tool",
+        "tool": "supabase_table_query",
+        "in": {
+          "integration_resource_id": "${trigger.config.supabase_integration_id}",
+          "table": "signups",
+          "filters": {"welcome_sent": {"eq": false}}
+        },
+        "out": "signups"
+      },
+      {
+        "id": "send_welcome_emails",
+        "type": "for_each",
+        "items": "${signups}",
+        "item_var": "signup",
+        "body": [
+          {
+            "id": "send_email",
+            "type": "tool",
+            "tool": "gmail_send_email",
+            "in": {
+              "integration_resource_id": "${trigger.config.gmail_integration_id}",
+              "to": ["${signup.email}"],
+              "subject": "Welcome to Our Platform!",
+              "body_text": "Hi ${signup.name}, welcome!"
+            },
+            "out": "email_result"
+          },
+          {
+            "id": "mark_sent",
+            "type": "tool",
+            "tool": "supabase_table_update",
+            "in": {
+              "integration_resource_id": "${trigger.config.supabase_integration_id}",
+              "table": "signups",
+              "filters": {"id": {"eq": "${signup.id}"}},
+              "values": {"welcome_sent": true}
+            },
+            "out": "update_result"
+          }
+        ],
+        "out": "results"
+      }
+    ],
+    "edges": [
+      {"from": "_start", "to": "fetch_new_signups"},
+      {"from": "fetch_new_signups", "to": "send_welcome_emails"},
+      {"from": "send_welcome_emails", "to": "_end"}
+    ],
+    "output": "${results}"
+  }
+}

--- a/workflow_compiler/schema/examples/v2/05_complex_multi_step.json
+++ b/workflow_compiler/schema/examples/v2/05_complex_multi_step.json
@@ -1,0 +1,143 @@
+{
+  "name": "Daily Sales Report Generator",
+  "description": "Fetch sales and inventory in parallel, generate report, email to stakeholders",
+  "tags": ["reporting", "parallel", "sheets"],
+  "spec": {
+    "triggers": [{
+      "key": "schedule.cron",
+      "config": {
+        "cron": "0 8 * * 1-5",
+        "timezone": "UTC",
+        "supabase_integration_id": 105,
+        "sheets_integration_id": 106,
+        "gmail_integration_id": 107
+      }
+    }],
+    "inputs": {},
+    "nodes": [
+      {
+        "id": "fetch_sales",
+        "type": "tool",
+        "tool": "supabase_table_query",
+        "in": {
+          "integration_resource_id": "${trigger.config.supabase_integration_id}",
+          "table": "sales",
+          "filters": {"created_at": {"gte": "${trigger.data.yesterday_start}"}}
+        },
+        "out": "sales"
+      },
+      {
+        "id": "fetch_inventory",
+        "type": "tool",
+        "tool": "supabase_table_query",
+        "in": {
+          "integration_resource_id": "${trigger.config.supabase_integration_id}",
+          "table": "inventory",
+          "filters": {"low_stock": {"eq": true}}
+        },
+        "out": "inventory"
+      },
+      {
+        "id": "calculate_metrics",
+        "type": "llm",
+        "model": "gpt-4o-mini",
+        "prompt": "Analyze sales: ${sales} and inventory: ${inventory}. Generate summary with total revenue, units sold, low stock alerts.",
+        "out": "metrics",
+        "output": {
+          "mode": "json",
+          "schema": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "total_revenue": {"type": "number"},
+                "units_sold": {"type": "integer"},
+                "low_stock_items": {"type": "array"}
+              }
+            }
+          }
+        }
+      },
+      {
+        "id": "check_low_stock",
+        "type": "if",
+        "condition": "${metrics.low_stock_items}",
+        "then": [
+          {
+            "id": "format_alert",
+            "type": "task",
+            "kind": "set",
+            "value": "⚠️ LOW STOCK ALERT:\n${metrics.low_stock_items}",
+            "out": "alert_text"
+          }
+        ],
+        "else": [
+          {
+            "id": "no_alert",
+            "type": "task",
+            "kind": "set",
+            "value": "✅ All inventory levels healthy",
+            "out": "alert_text"
+          }
+        ],
+        "out": "alert"
+      },
+      {
+        "id": "write_to_sheets",
+        "type": "tool",
+        "tool": "google_sheets_append",
+        "in": {
+          "integration_resource_id": "${trigger.config.sheets_integration_id}",
+          "spreadsheet_id": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms",
+          "range": "Daily Reports!A:D",
+          "values": [[
+            "${trigger.data.scheduled_time}",
+            "${metrics.total_revenue}",
+            "${metrics.units_sold}",
+            "${alert}"
+          ]]
+        },
+        "out": "sheet_result"
+      },
+      {
+        "id": "set_recipients",
+        "type": "task",
+        "kind": "set",
+        "value": ["sales@company.com", "inventory@company.com"],
+        "out": "recipients"
+      },
+      {
+        "id": "send_reports",
+        "type": "for_each",
+        "items": "${recipients}",
+        "item_var": "recipient",
+        "body": [
+          {
+            "id": "send_report_email",
+            "type": "tool",
+            "tool": "gmail_send_email",
+            "in": {
+              "integration_resource_id": "${trigger.config.gmail_integration_id}",
+              "to": ["${recipient}"],
+              "subject": "Daily Sales Report - ${trigger.data.scheduled_time}",
+              "body_text": "Revenue: $${metrics.total_revenue}\nUnits: ${metrics.units_sold}\n\n${alert}"
+            },
+            "out": "email_result"
+          }
+        ],
+        "out": "email_results"
+      }
+    ],
+    "edges": [
+      {"from": "_start", "to": "fetch_sales"},
+      {"from": "_start", "to": "fetch_inventory"},
+      {"from": "fetch_sales", "to": "calculate_metrics"},
+      {"from": "fetch_inventory", "to": "calculate_metrics"},
+      {"from": "calculate_metrics", "to": "check_low_stock"},
+      {"from": "check_low_stock", "to": "write_to_sheets"},
+      {"from": "write_to_sheets", "to": "set_recipients"},
+      {"from": "set_recipients", "to": "send_reports"},
+      {"from": "send_reports", "to": "_end"}
+    ],
+    "output": "${email_results}"
+  }
+}

--- a/workflow_compiler/schema/examples/v2/06_database_crud.json
+++ b/workflow_compiler/schema/examples/v2/06_database_crud.json
@@ -1,0 +1,76 @@
+{
+  "name": "User Profile Update Handler",
+  "description": "Handle user profile updates with audit logging",
+  "tags": ["crud", "database", "audit"],
+  "spec": {
+    "triggers": [{
+      "key": "webhook.supabase.db_changes",
+      "config": {
+        "integration_resource_id": 108,
+        "gmail_integration_id": 200,
+        "table": "user_profiles",
+        "events": ["UPDATE"]
+      }
+    }],
+    "inputs": {},
+    "nodes": [
+      {
+        "id": "extract_changes",
+        "type": "task",
+        "kind": "set",
+        "value": {
+          "user_id": "${trigger.data.record.id}",
+          "old_email": "${trigger.data.old_record.email}",
+          "new_email": "${trigger.data.record.email}",
+          "changed_at": "${trigger.data.commit_timestamp}"
+        },
+        "out": "changes"
+      },
+      {
+        "id": "log_audit",
+        "type": "tool",
+        "tool": "supabase_table_insert",
+        "in": {
+          "integration_resource_id": "${trigger.config.integration_resource_id}",
+          "table": "audit_log",
+          "values": {
+            "user_id": "${changes.user_id}",
+            "action": "profile_update",
+            "old_value": "${changes.old_email}",
+            "new_value": "${changes.new_email}",
+            "timestamp": "${changes.changed_at}"
+          }
+        },
+        "out": "audit_result"
+      },
+      {
+        "id": "check_email_changed",
+        "type": "if",
+        "condition": "${changes.old_email != changes.new_email}",
+        "then": [
+          {
+            "id": "send_verification",
+            "type": "tool",
+            "tool": "gmail_send_email",
+            "in": {
+              "integration_resource_id": "${trigger.config.gmail_integration_id}",
+              "to": ["${changes.new_email}"],
+              "subject": "Verify Your New Email",
+              "body_text": "Please verify your email change."
+            },
+            "out": "verification_result"
+          }
+        ],
+        "else": [],
+        "out": "email_result"
+      }
+    ],
+    "edges": [
+      {"from": "_start", "to": "extract_changes"},
+      {"from": "extract_changes", "to": "log_audit"},
+      {"from": "log_audit", "to": "check_email_changed"},
+      {"from": "check_email_changed", "to": "_end"}
+    ],
+    "output": "${audit_result}"
+  }
+}

--- a/workflow_compiler/schema/examples/v2/07_file_processing_pipeline.json
+++ b/workflow_compiler/schema/examples/v2/07_file_processing_pipeline.json
@@ -1,0 +1,87 @@
+{
+  "name": "Document Processing Pipeline",
+  "description": "Extract insights from uploaded documents using AI",
+  "tags": ["gdrive", "ai", "processing"],
+  "spec": {
+    "triggers": [{
+      "key": "webhook.google.drive.file_created",
+      "config": {
+        "integration_resource_id": 109,
+        "supabase_integration_id": 110,
+        "gmail_integration_id": 111,
+        "folder_id": "1xyz9876folder"
+      }
+    }],
+    "inputs": {},
+    "nodes": [
+      {
+        "id": "download_file",
+        "type": "tool",
+        "tool": "gdrive_download_file",
+        "in": {
+          "integration_resource_id": "${trigger.config.integration_resource_id}",
+          "file_id": "${trigger.data.file_id}"
+        },
+        "out": "file_content"
+      },
+      {
+        "id": "extract_insights",
+        "type": "llm",
+        "model": "gpt-4o",
+        "prompt": "Extract key insights from this document:\n\n${file_content}",
+        "out": "insights",
+        "output": {
+          "mode": "json",
+          "schema": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "summary": {"type": "string"},
+                "key_points": {"type": "array"},
+                "sentiment": {"type": "string"}
+              }
+            }
+          }
+        }
+      },
+      {
+        "id": "save_to_db",
+        "type": "tool",
+        "tool": "supabase_table_insert",
+        "in": {
+          "integration_resource_id": "${trigger.config.supabase_integration_id}",
+          "table": "document_insights",
+          "values": {
+            "file_id": "${trigger.data.file_id}",
+            "file_name": "${trigger.data.name}",
+            "summary": "${insights.summary}",
+            "key_points": "${insights.key_points}",
+            "sentiment": "${insights.sentiment}",
+            "processed_at": "${trigger.data.created_time}"
+          }
+        },
+        "out": "db_result"
+      },
+      {
+        "id": "notify_complete",
+        "type": "tool",
+        "tool": "gmail_send_email",
+        "in": {
+          "integration_resource_id": "${trigger.config.gmail_integration_id}",
+          "to": ["user@company.com"],
+          "subject": "Document Processed: ${trigger.data.name}",
+          "body_text": "Summary: ${insights.summary}"
+        },
+        "out": "notification_result"
+      }
+    ],
+    "edges": [
+      {"from": "_start", "to": "download_file"},
+      {"from": "download_file", "to": "extract_insights"},
+      {"from": "extract_insights", "to": "save_to_db"},
+      {"from": "save_to_db", "to": "notify_complete"},
+      {"from": "notify_complete", "to": "_end"}
+    ],
+    "output": "${db_result}"
+  }
+}

--- a/workflow_compiler/schema/v2_schema.json
+++ b/workflow_compiler/schema/v2_schema.json
@@ -1,0 +1,190 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Seer Workflow V2",
+  "type": "object",
+  "required": ["name", "spec"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 255,
+      "description": "Workflow display name"
+    },
+    "description": {
+      "type": "string",
+      "description": "Human-readable workflow description"
+    },
+    "tags": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Tags for categorization"
+    },
+    "spec": {
+      "type": "object",
+      "required": ["nodes", "edges"],
+      "properties": {
+        "triggers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["key"],
+            "properties": {
+              "key": {
+                "type": "string",
+                "description": "Trigger key (e.g., 'schedule.cron')"
+              },
+              "config": {
+                "type": "object",
+                "description": "Trigger-specific configuration"
+              },
+              "filters": {
+                "type": "object",
+                "description": "Event filters"
+              }
+            }
+          }
+        },
+        "nodes": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {"$ref": "#/definitions/TaskNode"},
+              {"$ref": "#/definitions/ToolNode"},
+              {"$ref": "#/definitions/LLMNode"},
+              {"$ref": "#/definitions/IfNode"},
+              {"$ref": "#/definitions/ForEachNode"}
+            ]
+          }
+        },
+        "edges": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["from", "to"],
+            "properties": {
+              "from": {"type": "string"},
+              "to": {"type": "string"}
+            }
+          }
+        },
+        "output": {
+          "description": "Expression defining workflow output"
+        },
+        "ui": {
+          "type": "object",
+          "description": "UI-only metadata (positions, visual edges)",
+          "properties": {
+            "nodes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {"type": "string"},
+                  "position": {
+                    "type": "object",
+                    "properties": {
+                      "x": {"type": "number"},
+                      "y": {"type": "number"}
+                    }
+                  }
+                }
+              }
+            },
+            "edges": {"type": "array"}
+          }
+        }
+      }
+    },
+    "metadata": {
+      "type": "object",
+      "description": "User-facing metadata",
+      "properties": {
+        "version": {"type": "string"},
+        "created_by": {"type": "string"},
+        "created_at": {"type": "string", "format": "date-time"},
+        "updated_at": {"type": "string", "format": "date-time"}
+      }
+    }
+  },
+  "definitions": {
+    "TaskNode": {
+      "type": "object",
+      "required": ["id", "type", "kind"],
+      "properties": {
+        "id": {"type": "string"},
+        "type": {"const": "task"},
+        "kind": {"enum": ["set"]},
+        "value": {},
+        "in": {"type": "object"},
+        "out": {"type": "string"},
+        "output": {"$ref": "#/definitions/OutputContract"}
+      }
+    },
+    "ToolNode": {
+      "type": "object",
+      "required": ["id", "type", "tool"],
+      "properties": {
+        "id": {"type": "string"},
+        "type": {"const": "tool"},
+        "tool": {"type": "string", "minLength": 1},
+        "in": {"type": "object"},
+        "out": {"type": "string"},
+        "expect_output": {"$ref": "#/definitions/OutputContract"}
+      }
+    },
+    "LLMNode": {
+      "type": "object",
+      "required": ["id", "type", "model", "prompt"],
+      "properties": {
+        "id": {"type": "string"},
+        "type": {"const": "llm"},
+        "model": {"type": "string"},
+        "prompt": {"type": "string"},
+        "in": {"type": "object"},
+        "out": {"type": "string"},
+        "output": {"$ref": "#/definitions/OutputContract"},
+        "temperature": {"type": "number"},
+        "max_tokens": {"type": "integer"}
+      }
+    },
+    "IfNode": {
+      "type": "object",
+      "required": ["id", "type", "condition"],
+      "properties": {
+        "id": {"type": "string"},
+        "type": {"const": "if"},
+        "condition": {"type": "string"},
+        "then": {"type": "array"},
+        "else": {"type": "array"},
+        "out": {"type": "string"}
+      }
+    },
+    "ForEachNode": {
+      "type": "object",
+      "required": ["id", "type", "items"],
+      "properties": {
+        "id": {"type": "string"},
+        "type": {"const": "for_each"},
+        "items": {"type": "string"},
+        "body": {"type": "array"},
+        "item_var": {"type": "string", "default": "item"},
+        "index_var": {"type": "string", "default": "index"},
+        "out": {"type": "string"},
+        "output": {"$ref": "#/definitions/OutputContract"}
+      }
+    },
+    "OutputContract": {
+      "type": "object",
+      "required": ["mode"],
+      "properties": {
+        "mode": {"enum": ["text", "json"]},
+        "schema": {
+          "oneOf": [
+            {"type": "object"},
+            {"type": "object", "required": ["id"], "properties": {"id": {"type": "string"}}}
+          ]
+        }
+      }
+    }
+  }
+}

--- a/workflow_compiler/schema/validate_v2.py
+++ b/workflow_compiler/schema/validate_v2.py
@@ -1,0 +1,229 @@
+"""
+V2 Workflow Schema Validator
+
+Validates workflow specs against V2 schema with:
+- Structure validation (JSON Schema)
+- DAG validation (cycles, orphans, connectivity)
+- Reference validation (node IDs, template expressions)
+"""
+# pylint: disable=too-many-branches  # Validation logic requires multiple conditional checks
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+import networkx as nx
+from jsonschema import ValidationError as JSONSchemaValidationError
+from jsonschema import validate
+
+
+class ValidationError(Exception):
+    """Workflow validation error"""
+
+    def __init__(self, message: str, path: str | None = None):
+        self.message = message
+        self.path = path
+        super().__init__(f"{path}: {message}" if path else message)
+
+
+class WorkflowValidator:
+    """Validates V2 workflow specifications"""
+
+    def __init__(self, schema: Dict[str, Any]):
+        """Initialize with JSON Schema"""
+        self.schema = schema
+
+    def validate(self, workflow: Dict[str, Any]) -> List[ValidationError]:
+        """Validate workflow and return all errors"""
+        errors: List[ValidationError] = []
+
+        # 1. JSON Schema validation
+        try:
+            validate(instance=workflow, schema=self.schema)
+        except JSONSchemaValidationError as e:
+            errors.append(
+                ValidationError(
+                    f"Schema validation failed: {e.message}",
+                    path=".".join(str(p) for p in e.path) if e.path else None,
+                )
+            )
+            return errors  # Don't continue if structure is invalid
+
+        spec = workflow.get("spec", {})
+
+        # 2. DAG validation
+        errors.extend(self._validate_dag(spec.get("nodes", []), spec.get("edges", [])))
+
+        # 3. Node reference validation
+        errors.extend(self._validate_node_references(spec.get("nodes", []), spec.get("edges", [])))
+
+        # 4. Template expression validation (basic syntax)
+        errors.extend(self._validate_expressions(spec))
+
+        return errors
+
+    # pylint: disable=too-complex  # DAG validation requires multiple conditional checks
+    def _validate_dag(
+        self, nodes: List[Dict[str, Any]], edges: List[Dict[str, Any]]
+    ) -> List[ValidationError]:
+        """Validate DAG properties: no cycles, connectivity"""
+        errors: List[ValidationError] = []
+
+        if not edges:
+            # Empty edges is OK (fallback to sequential)
+            return errors
+
+        # Build node ID set
+        node_ids = {n["id"] for n in nodes}
+        node_ids.add("_start")
+        node_ids.add("_end")
+
+        # Build graph
+        graph = nx.DiGraph()
+
+        for edge in edges:
+            from_id = edge["from"]
+            to_id = edge["to"]
+
+            # Check edge nodes exist
+            if from_id not in node_ids:
+                errors.append(
+                    ValidationError(
+                        f"Edge references unknown node: '{from_id}'",
+                        path="spec.edges",
+                    )
+                )
+            if to_id not in node_ids:
+                errors.append(
+                    ValidationError(
+                        f"Edge references unknown node: '{to_id}'",
+                        path="spec.edges",
+                    )
+                )
+
+            graph.add_edge(from_id, to_id)
+
+        # Check for cycles
+        try:
+            cycles = list(nx.simple_cycles(graph))
+            if cycles:
+                for cycle in cycles:
+                    errors.append(
+                        ValidationError(
+                            f"DAG contains cycle: {' -> '.join(cycle)}",
+                            path="spec.edges",
+                        )
+                    )
+        except (nx.NetworkXError, RuntimeError) as e:  # NetworkX-specific errors
+            errors.append(
+                ValidationError(
+                    f"Failed to check for cycles: {e}",
+                    path="spec.edges",
+                )
+            )
+
+        # Check for orphaned nodes (no incoming or outgoing edges)
+        for node_id in node_ids:
+            if node_id in ("_start", "_end"):
+                continue
+            if node_id not in graph:
+                errors.append(
+                    ValidationError(
+                        f"Node '{node_id}' has no incoming or outgoing edges (orphaned)",
+                        path="spec.nodes",
+                    )
+                )
+
+        # Check connectivity (all nodes reachable from _start)
+        if "_start" in graph:
+            reachable = nx.descendants(graph, "_start")
+            reachable.add("_start")
+            for node_id in node_ids:
+                if node_id not in reachable and node_id != "_end":
+                    errors.append(
+                        ValidationError(
+                            f"Node '{node_id}' is not reachable from _start",
+                            path="spec.nodes",
+                        )
+                    )
+
+        return errors
+
+    def _validate_node_references(
+        self, nodes: List[Dict[str, Any]], edges: List[Dict[str, Any]]
+    ) -> List[ValidationError]:
+        """Validate that all nodes in edges exist"""
+        errors: List[ValidationError] = []
+        node_ids = {n["id"] for n in nodes}
+
+        for edge in edges:
+            from_id = edge["from"]
+            to_id = edge["to"]
+
+            if from_id not in node_ids and from_id not in ("_start", "_end"):
+                errors.append(
+                    ValidationError(
+                        f"Edge 'from' references non-existent node: '{from_id}'",
+                        path="spec.edges",
+                    )
+                )
+
+            if to_id not in node_ids and to_id not in ("_start", "_end"):
+                errors.append(
+                    ValidationError(
+                        f"Edge 'to' references non-existent node: '{to_id}'",
+                        path="spec.edges",
+                    )
+                )
+
+        return errors
+
+    # pylint: disable=too-complex  # Expression validation requires nested recursive checks
+    def _validate_expressions(self, spec: Dict[str, Any]) -> List[ValidationError]:
+        """Validate template expressions (basic syntax check)"""
+        errors: List[ValidationError] = []
+
+        # Check for balanced ${ } braces
+        def check_expr(text: str, path: str) -> None:
+            if not isinstance(text, str):
+                return
+            open_count = text.count("${")
+            close_count = text.count("}")
+            if open_count != close_count:
+                errors.append(
+                    ValidationError(
+                        "Unbalanced template expression braces",
+                        path=path,
+                    )
+                )
+
+        # Check all string fields recursively
+        def check_dict(d: Dict[str, Any], path: str) -> None:
+            for key, value in d.items():
+                new_path = f"{path}.{key}" if path else key
+                if isinstance(value, str):
+                    check_expr(value, new_path)
+                elif isinstance(value, dict):
+                    check_dict(value, new_path)
+                elif isinstance(value, list):
+                    for i, item in enumerate(value):
+                        if isinstance(item, dict):
+                            check_dict(item, f"{new_path}[{i}]")
+                        elif isinstance(item, str):
+                            check_expr(item, f"{new_path}[{i}]")
+
+        check_dict(spec, "spec")
+
+        return errors
+
+
+def validate_workflow_v2(workflow: Dict[str, Any], schema: Dict[str, Any]) -> Tuple[bool, List[str]]:
+    """
+    Validate a V2 workflow.
+
+    Returns:
+        (is_valid, errors)
+    """
+    validator = WorkflowValidator(schema)
+    errors = validator.validate(workflow)
+    return len(errors) == 0, [str(e) for e in errors]

--- a/workflow_compiler/tests/test_validate_v2.py
+++ b/workflow_compiler/tests/test_validate_v2.py
@@ -1,0 +1,275 @@
+"""Tests for V2 workflow schema validator"""
+# pylint: disable=redefined-outer-name  # pytest fixture pattern
+
+import json
+from pathlib import Path
+
+import pytest
+
+from workflow_compiler.schema.validate_v2 import WorkflowValidator, validate_workflow_v2
+
+
+@pytest.fixture
+def v2_schema():
+    """Load V2 JSON Schema"""
+    schema_path = Path(__file__).parent.parent / "schema" / "v2_schema.json"
+    with open(schema_path, encoding='utf-8') as f:
+        return json.load(f)
+
+
+@pytest.fixture
+def validator(v2_schema):
+    """Create workflow validator"""
+    return WorkflowValidator(v2_schema)
+
+
+class TestSchemaValidation:
+    """Test JSON Schema validation"""
+
+    def test_minimal_valid_workflow(self, validator):
+        """Test minimal valid workflow passes validation"""
+        workflow = {
+            "name": "Test Workflow",
+            "spec": {
+                "nodes": [],
+                "edges": []
+            }
+        }
+        errors = validator.validate(workflow)
+        assert len(errors) == 0
+
+    def test_missing_required_fields(self, validator):
+        """Test workflow missing required fields fails"""
+        workflow = {}  # Missing 'name' and 'spec'
+        errors = validator.validate(workflow)
+        assert len(errors) > 0
+        assert any("required" in str(e).lower() for e in errors)
+
+    def test_invalid_node_type(self, validator):
+        """Test workflow with invalid node type fails"""
+        workflow = {
+            "name": "Test",
+            "spec": {
+                "nodes": [{"id": "test", "type": "invalid_type"}],
+                "edges": []
+            }
+        }
+        errors = validator.validate(workflow)
+        assert len(errors) > 0
+
+
+class TestDAGValidation:
+    """Test DAG structure validation"""
+
+    def test_simple_sequential_dag(self, validator):
+        """Test simple sequential DAG is valid"""
+        workflow = {
+            "name": "Sequential",
+            "spec": {
+                "nodes": [
+                    {"id": "node1", "type": "task", "kind": "set", "value": "test"},
+                    {"id": "node2", "type": "task", "kind": "set", "value": "test2"}
+                ],
+                "edges": [
+                    {"from": "_start", "to": "node1"},
+                    {"from": "node1", "to": "node2"},
+                    {"from": "node2", "to": "_end"}
+                ]
+            }
+        }
+        errors = validator.validate(workflow)
+        assert len(errors) == 0
+
+    def test_parallel_dag(self, validator):
+        """Test parallel DAG is valid"""
+        workflow = {
+            "name": "Parallel",
+            "spec": {
+                "nodes": [
+                    {"id": "node1", "type": "task", "kind": "set", "value": "test1"},
+                    {"id": "node2", "type": "task", "kind": "set", "value": "test2"},
+                    {"id": "node3", "type": "task", "kind": "set", "value": "test3"}
+                ],
+                "edges": [
+                    {"from": "_start", "to": "node1"},
+                    {"from": "_start", "to": "node2"},
+                    {"from": "node1", "to": "node3"},
+                    {"from": "node2", "to": "node3"},
+                    {"from": "node3", "to": "_end"}
+                ]
+            }
+        }
+        errors = validator.validate(workflow)
+        assert len(errors) == 0
+
+    def test_cycle_detection(self, validator):
+        """Test cycle in DAG is detected"""
+        workflow = {
+            "name": "Cycle",
+            "spec": {
+                "nodes": [
+                    {"id": "node1", "type": "task", "kind": "set", "value": "test1"},
+                    {"id": "node2", "type": "task", "kind": "set", "value": "test2"}
+                ],
+                "edges": [
+                    {"from": "_start", "to": "node1"},
+                    {"from": "node1", "to": "node2"},
+                    {"from": "node2", "to": "node1"},  # Cycle!
+                    {"from": "node2", "to": "_end"}
+                ]
+            }
+        }
+        errors = validator.validate(workflow)
+        assert len(errors) > 0
+        assert any("cycle" in str(e).lower() for e in errors)
+
+    def test_orphaned_node_detection(self, validator):
+        """Test orphaned node is detected"""
+        workflow = {
+            "name": "Orphaned",
+            "spec": {
+                "nodes": [
+                    {"id": "node1", "type": "task", "kind": "set", "value": "test1"},
+                    {"id": "node2", "type": "task", "kind": "set", "value": "test2"}
+                ],
+                "edges": [
+                    {"from": "_start", "to": "node1"},
+                    {"from": "node1", "to": "_end"}
+                    # node2 is orphaned - no edges!
+                ]
+            }
+        }
+        errors = validator.validate(workflow)
+        assert len(errors) > 0
+        assert any("orphan" in str(e).lower() for e in errors)
+
+    def test_unknown_node_in_edge(self, validator):
+        """Test edge referencing unknown node fails"""
+        workflow = {
+            "name": "Unknown",
+            "spec": {
+                "nodes": [
+                    {"id": "node1", "type": "task", "kind": "set", "value": "test1"}
+                ],
+                "edges": [
+                    {"from": "_start", "to": "node1"},
+                    {"from": "node1", "to": "unknown_node"},  # Unknown!
+                    {"from": "unknown_node", "to": "_end"}
+                ]
+            }
+        }
+        errors = validator.validate(workflow)
+        assert len(errors) > 0
+        assert any("unknown" in str(e).lower() for e in errors)
+
+    def test_empty_edges_allowed(self, validator):
+        """Test empty edges list is allowed (fallback to sequential)"""
+        workflow = {
+            "name": "No Edges",
+            "spec": {
+                "nodes": [
+                    {"id": "node1", "type": "task", "kind": "set", "value": "test1"}
+                ],
+                "edges": []
+            }
+        }
+        errors = validator.validate(workflow)
+        # Empty edges should not cause errors (fallback behavior)
+        assert len([e for e in errors if "edge" in str(e).lower()]) == 0
+
+
+class TestTemplateExpressions:
+    """Test template expression validation"""
+
+    def test_valid_expressions(self, validator):
+        """Test valid template expressions pass"""
+        workflow = {
+            "name": "Valid Expressions",
+            "spec": {
+                "nodes": [
+                    {
+                        "id": "node1",
+                        "type": "tool",
+                        "tool": "test_tool",
+                        "in": {
+                            "field1": "${trigger.data.value}",
+                            "field2": "${trigger.config.user_id}"
+                        }
+                    }
+                ],
+                "edges": [
+                    {"from": "_start", "to": "node1"},
+                    {"from": "node1", "to": "_end"}
+                ]
+            }
+        }
+        errors = validator.validate(workflow)
+        # Should not have expression errors
+        assert len([e for e in errors if "brace" in str(e).lower()]) == 0
+
+    def test_unbalanced_braces(self, validator):
+        """Test unbalanced braces are detected"""
+        workflow = {
+            "name": "Unbalanced",
+            "spec": {
+                "nodes": [
+                    {
+                        "id": "node1",
+                        "type": "tool",
+                        "tool": "test_tool",
+                        "in": {
+                            "field1": "${trigger.data.value"  # Missing }
+                        }
+                    }
+                ],
+                "edges": [
+                    {"from": "_start", "to": "node1"},
+                    {"from": "node1", "to": "_end"}
+                ]
+            }
+        }
+        errors = validator.validate(workflow)
+        assert len(errors) > 0
+        assert any("brace" in str(e).lower() for e in errors)
+
+
+class TestExampleWorkflows:
+    """Test all example workflows are valid"""
+
+    @pytest.fixture
+    def examples_dir(self):
+        """Get examples directory"""
+        return Path(__file__).parent.parent / "schema" / "examples" / "v2"
+
+    def test_all_examples_valid(self, examples_dir, v2_schema):
+        """Test all example workflows pass validation"""
+        example_files = sorted(examples_dir.glob("*.json"))
+        assert len(example_files) == 7, f"Expected 7 examples, found {len(example_files)}"
+
+        for example_file in example_files:
+            with open(example_file, encoding='utf-8') as f:
+                workflow = json.load(f)
+
+            is_valid, errors = validate_workflow_v2(workflow, v2_schema)
+            assert is_valid, f"{example_file.name} failed validation: {errors}"
+
+    def test_example_01_simple_email_alert(self, examples_dir, v2_schema):
+        """Test example 1: Simple email alert"""
+        with open(examples_dir / "01_simple_email_alert.json", encoding='utf-8') as f:
+            workflow = json.load(f)
+
+        is_valid, errors = validate_workflow_v2(workflow, v2_schema)
+        assert is_valid, f"Errors: {errors}"
+
+    def test_example_02_parallel_data_fetch(self, examples_dir, v2_schema):
+        """Test example 2: Parallel data fetching"""
+        with open(examples_dir / "02_parallel_data_fetch.json", encoding='utf-8') as f:
+            workflow = json.load(f)
+
+        is_valid, errors = validate_workflow_v2(workflow, v2_schema)
+        assert is_valid, f"Errors: {errors}"
+
+        # Verify it's actually parallel (multiple nodes from _start)
+        spec = workflow["spec"]
+        start_edges = [e for e in spec["edges"] if e["from"] == "_start"]
+        assert len(start_edges) == 2, "Should have 2 parallel branches from _start"


### PR DESCRIPTION
Remove redundant workflow-level inputs field. Inputs/outputs are now strictly node-level concepts via in/out fields, aligning with the visual workflow editor where nodes have input/output ports.

Changes:
- Remove inputs property from v2_schema.json
- Update all 7 example workflows to use empty inputs: {}
- Replace ${inputs.*} references with hardcoded values or node outputs
- Update README to clarify node-level inputs/outputs only
- Fix test reference from ${inputs.user_id} to ${trigger.config.user_id}
- Add pylint suppressions for validation complexity and pytest fixtures

All validation tests pass (14/14).