### PR TITLE
feat: add google analytics 4 to docs.getseer.dev with custom event tr…

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Build documentation
         run: npm run build
+        env:
+          GA_MEASUREMENT_ID: ${{ secrets.GA_MEASUREMENT_ID }}
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -35,6 +35,20 @@ const config: Config = {
     locales: ['en'],
   },
 
+  plugins: [
+    [
+      '@docusaurus/plugin-google-analytics',
+      {
+        trackingID: process.env.GA_MEASUREMENT_ID,
+        anonymizeIP: true,
+      },
+    ],
+  ],
+
+  clientModules: [
+    require.resolve('./src/clientModules/analytics.ts'),
+  ],
+
   presets: [
     [
       'classic',

--- a/documentation/package.json
+++ b/documentation/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "3.9.2",
+    "@docusaurus/plugin-google-analytics": "^3.9.2",
     "@docusaurus/preset-classic": "3.9.2",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",

--- a/documentation/src/clientModules/analytics.ts
+++ b/documentation/src/clientModules/analytics.ts
@@ -1,0 +1,40 @@
+// Client-side module for initializing custom analytics tracking
+// Automatically loaded by Docusaurus
+
+import { initializeCustomTracking, trackSearchQuery } from '../utils/analytics';
+
+export function onRouteDidUpdate() {
+  // Initialize custom tracking on every route change
+  initializeCustomTracking();
+
+  // Track Algolia search events
+  trackAlgoliaSearch();
+}
+
+/**
+ * Set up tracking for Algolia search queries
+ */
+function trackAlgoliaSearch() {
+  // Wait for Algolia/DocSearch to load
+  const checkAlgolia = setInterval(() => {
+    if (typeof window !== 'undefined' && (window as any).docsearch) {
+      clearInterval(checkAlgolia);
+
+      // Hook into DocSearch events if available
+      const searchInputs = document.querySelectorAll('input[placeholder*="Search"]');
+      searchInputs.forEach((input) => {
+        input.addEventListener('keydown', (e) => {
+          if ((e as KeyboardEvent).key === 'Enter') {
+            const query = (e.target as HTMLInputElement).value;
+            if (query.trim()) {
+              trackSearchQuery(query);
+            }
+          }
+        });
+      });
+    }
+  }, 500);
+
+  // Stop checking after 5 seconds if Algolia doesn't load
+  setTimeout(() => clearInterval(checkAlgolia), 5000);
+}

--- a/documentation/src/theme/CodeBlock/index.tsx
+++ b/documentation/src/theme/CodeBlock/index.tsx
@@ -1,0 +1,38 @@
+import React, { useEffect } from 'react';
+import CodeBlockOriginal from '@theme-original/CodeBlock';
+import { trackCodeCopy } from '@site/src/utils/analytics';
+import type { Props } from '@theme/CodeBlock';
+
+export default function CodeBlock(props: Props): JSX.Element {
+  useEffect(() => {
+    // Add tracking to copy buttons after component renders
+    const copyButtons = document.querySelectorAll(
+      '[class*="copyButton"], [aria-label*="Copy"]'
+    );
+
+    const handleCopyClick = (event: Event) => {
+      const button = event.target as HTMLElement;
+      const codeBlock = button.closest('[class*="codeBlockContent"]');
+
+      if (codeBlock) {
+        const language = button.closest('[class*="codeBlock"]')?.getAttribute('data-language') || 'unknown';
+        const codeText = codeBlock.textContent || '';
+        const preview = codeText.substring(0, 50); // First 50 chars for preview
+
+        trackCodeCopy(language, preview);
+      }
+    };
+
+    copyButtons.forEach((button) => {
+      button.addEventListener('click', handleCopyClick);
+    });
+
+    return () => {
+      copyButtons.forEach((button) => {
+        button.removeEventListener('click', handleCopyClick);
+      });
+    };
+  }, []);
+
+  return <CodeBlockOriginal {...props} />;
+}

--- a/documentation/src/utils/analytics.ts
+++ b/documentation/src/utils/analytics.ts
@@ -1,0 +1,118 @@
+// Google Analytics 4 event tracking utilities
+// Only active in production builds
+
+/**
+ * Fire a custom GA4 event
+ */
+export function trackEvent(eventName: string, eventParams?: Record<string, any>) {
+  if (typeof window !== 'undefined' && window.gtag) {
+    window.gtag('event', eventName, eventParams);
+  }
+}
+
+/**
+ * Track search query events from Algolia
+ */
+export function trackSearchQuery(query: string, resultCount?: number) {
+  trackEvent('search_query', {
+    search_term: query,
+    result_count: resultCount,
+  });
+}
+
+/**
+ * Track external link clicks
+ */
+export function trackExternalLinkClick(url: string, linkText?: string) {
+  trackEvent('external_link_click', {
+    link_url: url,
+    link_text: linkText,
+  });
+}
+
+/**
+ * Track code block copy events
+ */
+export function trackCodeCopy(language?: string, codePreview?: string) {
+  trackEvent('code_copy', {
+    language: language || 'unknown',
+    code_preview: codePreview || '',
+  });
+}
+
+/**
+ * Track scroll depth milestones
+ */
+export function trackScrollDepth(depth: number) {
+  trackEvent('scroll_depth', {
+    scroll_percentage: depth,
+  });
+}
+
+/**
+ * Initialize custom event tracking handlers
+ */
+export function initializeCustomTracking() {
+  // Only initialize in production (GA4 plugin handles this, but be explicit)
+  if (process.env.NODE_ENV !== 'production') {
+    return;
+  }
+
+  // Track external links
+  trackExternalLinks();
+
+  // Track scroll depth
+  trackScrollDepth_();
+
+  // Algolia search tracking is handled separately via docusaurus search integration
+}
+
+/**
+ * Add click tracking to external links
+ */
+function trackExternalLinks() {
+  document.addEventListener('click', (event) => {
+    const target = event.target as HTMLElement;
+    const link = target.closest('a');
+
+    if (!link) return;
+
+    const href = link.getAttribute('href');
+    const text = link.textContent || '';
+
+    // Only track external links (not same-origin)
+    if (href && !href.startsWith('/') && !href.startsWith('#')) {
+      trackExternalLinkClick(href, text.trim());
+    }
+  });
+}
+
+/**
+ * Track scroll depth at 25%, 50%, 75%, and 100%
+ */
+function trackScrollDepth_() {
+  const trackingThresholds = [25, 50, 75, 100];
+  const tracked = new Set<number>();
+
+  window.addEventListener('scroll', () => {
+    if (document.body.scrollHeight === 0) return;
+
+    const scrollPercentage = Math.round(
+      (window.scrollY / (document.body.scrollHeight - window.innerHeight)) * 100
+    );
+
+    for (const threshold of trackingThresholds) {
+      if (scrollPercentage >= threshold && !tracked.has(threshold)) {
+        tracked.add(threshold);
+        trackScrollDepth(threshold);
+      }
+    }
+  });
+}
+
+// Extend Window interface for TypeScript
+declare global {
+  interface Window {
+    gtag?: (...args: any[]) => void;
+  }
+}


### PR DESCRIPTION
Add GA4 integration for documentation site with event tracking for search queries, external link clicks, code copies, and scroll depth. Configure to production-only (disabled in dev) with IP anonymization for privacy compliance. Measurement ID passed via environment variable from GitHub Actions secret.
